### PR TITLE
Move tests to Aqua 0.8 (fixes CI on Julia 1.12)

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -4,4 +4,4 @@ FASTXDoReaders = "a10097c8-9f5b-4030-a7d7-d11adc5c7381"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [compat]
-Aqua = "0.7"
+Aqua = "0.8"


### PR DESCRIPTION
This repo's default branch is red, and not because of its own code.

Aqua below 0.8 **crashes on Julia 1.12**:

```
FieldError: type Core.TypeName has no field `mt`
  @ Aqua.Piracy ~/.julia/packages/Aqua/.../piracy.jl:55
```

`Core.TypeName.mt` was removed in Julia 1.12 and Aqua 0.8 accounts for it. While `test/Project.toml` bounds Aqua below 0.8, the resolver keeps picking a version that cannot run — so this surfaces as a *Piracy* failure that has nothing to do with type piracy.

Changes: pin `Aqua = "0.8"` (the fleet-wide bound), drop `project_toml_formatting` where present (removed in 0.8), and add any missing stdlib `[compat]` bound, which 0.8 also enforces.

Verified locally: both `Project.toml` files parse, every dep carries a bound, and `test/aqua.jl` parses under Julia 1.12.7.

Note: Aqua 0.8 runs checks the old version never reached, so if this repo has a *genuine* piracy or ambiguity issue it will now show up honestly instead of as a crash.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ErrTtLjrC2WAZCxgsDBGBY